### PR TITLE
feat(git): add git image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 !Dockerfile.base
 !dotfiles/
 !dotfiles/*
+!git/
+!git/*
 !Makefile

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
+build-git-bionic:
+	@docker image build \
+		--tag "git:bionic" \
+		--file $(shell pwd)/git/Dockerfile \
+		"$(shell pwd)/git"
+
 build-base:
 	@docker image build \
 		--progress="plain" \

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:18.04
+
+COPY "configure" "/tmp/configure"
+
+RUN \
+	/bin/bash /tmp/configure \
+	&& rm /tmp/configure
+
+CMD ["/bin/bash"]

--- a/git/configure
+++ b/git/configure
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e 
+
+#Install 'git' package
+apt-get update -y \
+ 	&& apt-get install -y \
+	git \
+	&& rm -Rf "/var/lib/apt/lists/*"


### PR DESCRIPTION
* Create image containing only `git`. This image is a building block of other images.
* Keep image configuration in separate directory with descriptive name.
* Add `configuration` script containing image configuration.
* Add building process to `Makefile`.