### PR TITLE
fix(git): fix formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build-tmux-bionic: build-git-bionic
 build-git-bionic:
 	@docker image build \
 		--tag "git:bionic" \
-		--file $(shell pwd)/git/Dockerfile \
+		--file "$(shell pwd)/git/Dockerfile" \
 		"$(shell pwd)/git"
 
 build-base-bionic: build-tmux-bionic

--- a/git/configure
+++ b/git/configure
@@ -2,7 +2,7 @@
 
 set -e 
 
-#Install 'git' package
+# Install 'git' package
 apt-get update -y \
  	&& apt-get install -y \
 	git \


### PR DESCRIPTION
* Add missing space after comment character. `# Install 'git' package`
* Surround path to `Dockerfile` with double quotes. `--file "$(shell pwd)/git/Dockerfile" \`